### PR TITLE
Run github actions on forked repo

### DIFF
--- a/.github/workflows/signup.yml
+++ b/.github/workflows/signup.yml
@@ -1,6 +1,6 @@
 name: Signup Form Link
 
-on: pull_request
+on: pull_request_target 
 
 jobs:
   signup_form_link:
@@ -13,5 +13,5 @@ jobs:
       - name: Comment on the PR with a signup form link
         uses: thollander/actions-comment-pull-request@master
         with:
-          message: 'Thanks for creating this PR. Please submit your details on [this form](http://aka.ms/golclinics-signup-1)'
+          message: 'Thanks for creating this PR. Please submit your details on [this form](${{ secrets.SIGNUP_FORM }})'
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/signup.yml
+++ b/.github/workflows/signup.yml
@@ -1,6 +1,6 @@
 name: Signup Form Link
 
-on: pull_request_target 
+on: [pull_request_target, pull_request]
 
 jobs:
   signup_form_link:


### PR DESCRIPTION
- Github has a security model that restricts github actions to run on forked repositories.
- This change uses another alternative github event that tries to overcome this limit.
- This change also secures the  signup form link so that it's only revealed when a pull request is created.